### PR TITLE
REFACTORING: fixing double pulling docker image in ghcr.io

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,19 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  push: {}
+  pull_request: {}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
-
     defaults:
       run:
         working-directory: frontend
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -38,6 +34,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
 
   build-and-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: lint
     permissions:


### PR DESCRIPTION
This pull request includes updates to the CI workflow configuration to streamline the process and improve efficiency. The most important changes involve modifying the triggers for the workflow and adding a conditional statement for the build-and-push job.

Changes to workflow triggers and job conditions:

* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L4-L16): Simplified the `push` and `pull_request` triggers to apply to all branches by setting them to empty objects.
* [`.github/workflows/CI.yml`](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R37): Added a conditional statement to the `build-and-push` job to ensure it only runs on pushes to the `main` branch.