### PR TITLE
fix(mfa-contracts): implement mfa, feature flags, and homepage enhancements

### DIFF
--- a/frontend/src/services/__tests__/mfaApi.test.js
+++ b/frontend/src/services/__tests__/mfaApi.test.js
@@ -7,6 +7,7 @@ import {
   getTotpStatus,
   getWebAuthnRegistrationOptions,
   getWebAuthnRequestOptions,
+  reauthenticateWithMfaCode,
 } from "../api/mfaApi";
 import { tokenStore } from "../auth/tokenStore";
 import { bareClient } from "../http/client";
@@ -65,6 +66,30 @@ describe("mfaApi", () => {
     });
 
     expect(tokenStore.get().session_token).toBe("mfa-session-token");
+  });
+
+  it("routes MFA reauthentication codes to the MFA reauth endpoint", async () => {
+    const requestSpy = vi.spyOn(bareClient, "request").mockResolvedValueOnce({
+      data: {
+        data: {
+          status: "ok",
+        },
+      },
+    });
+
+    await expect(reauthenticateWithMfaCode(" 123456 ")).resolves.toEqual({
+      data: {
+        status: "ok",
+      },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        url: "auth/flow/app/v1/auth/2fa/reauthenticate",
+        data: { code: "123456" },
+      }),
+    );
   });
 
   it("reads MFA config from the headless config endpoint", async () => {

--- a/frontend/src/services/__tests__/mfaApi.test.js
+++ b/frontend/src/services/__tests__/mfaApi.test.js
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { authenticateMfaCode, getTotpStatus } from "../api/mfaApi";
+import {
+  authenticateMfaCode,
+  getMfaConfig,
+  getTotpStatus,
+  getWebAuthnRegistrationOptions,
+  getWebAuthnRequestOptions,
+} from "../api/mfaApi";
 import { tokenStore } from "../auth/tokenStore";
 import { bareClient } from "../http/client";
 
@@ -58,5 +64,107 @@ describe("mfaApi", () => {
     });
 
     expect(tokenStore.get().session_token).toBe("mfa-session-token");
+  });
+
+  it("reads MFA config from the headless config endpoint", async () => {
+    const requestSpy = vi.spyOn(bareClient, "request").mockResolvedValueOnce({
+      data: {
+        data: {
+          mfa: {
+            supported_types: ["totp", "webauthn"],
+            passkey_login_enabled: true,
+          },
+        },
+      },
+    });
+
+    await expect(getMfaConfig()).resolves.toEqual({
+      supported_types: ["totp", "webauthn"],
+      passkey_login_enabled: true,
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "get",
+        url: "auth/flow/app/v1/config",
+      }),
+    );
+  });
+
+  it("derives passkey login support from unauthenticated config flows", async () => {
+    vi.spyOn(bareClient, "request").mockRejectedValueOnce(
+      httpError(401, {
+        data: {
+          flows: [
+            { id: "login" },
+            { id: "signup" },
+            { id: "mfa_login_webauthn" },
+          ],
+        },
+        meta: {
+          is_authenticated: null,
+        },
+      }),
+    );
+
+    await expect(getMfaConfig()).resolves.toEqual({
+      supported_types: [],
+      passkey_login_enabled: true,
+    });
+  });
+
+  it("requests reauthentication WebAuthn options from the dedicated endpoint", async () => {
+    const requestSpy = vi.spyOn(bareClient, "request").mockResolvedValueOnce({
+      data: {
+        data: {
+          request_options: {
+            challenge: "abc",
+            rpId: "joutak.ru",
+            rp: { id: "joutak.ru", name: "JouTak" },
+          },
+        },
+      },
+    });
+
+    await expect(getWebAuthnRequestOptions("reauthenticate")).resolves.toEqual({
+      challenge: "abc",
+      rpId: "joutak.ru",
+      rp: { id: "joutak.ru", name: "JouTak" },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "get",
+        url: "auth/flow/app/v1/auth/webauthn/reauthenticate",
+      }),
+    );
+  });
+
+  it("forwards passwordless registration mode when requested", async () => {
+    const requestSpy = vi.spyOn(bareClient, "request").mockResolvedValueOnce({
+      data: {
+        data: {
+          creation_options: {
+            challenge: "abc",
+            rp: { id: "joutak.ru", name: "JouTak" },
+          },
+        },
+      },
+    });
+
+    await expect(
+      getWebAuthnRegistrationOptions({ passwordless: true }),
+    ).resolves.toEqual({
+      challenge: "abc",
+      rp: { id: "joutak.ru", name: "JouTak" },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "get",
+        url: "auth/flow/app/v1/account/authenticators/webauthn",
+        params: { passwordless: "" },
+      }),
+    );
   });
 });

--- a/frontend/src/services/__tests__/mfaApi.test.js
+++ b/frontend/src/services/__tests__/mfaApi.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   authenticateMfaCode,
+  authenticateWithWebAuthnCredential,
   getMfaConfig,
   getTotpStatus,
   getWebAuthnRegistrationOptions,
@@ -136,6 +137,34 @@ describe("mfaApi", () => {
       expect.objectContaining({
         method: "get",
         url: "auth/flow/app/v1/auth/webauthn/reauthenticate",
+      }),
+    );
+  });
+
+  it("posts reauthentication WebAuthn credentials to the dedicated endpoint", async () => {
+    const requestSpy = vi.spyOn(bareClient, "request").mockResolvedValueOnce({
+      data: {
+        data: {
+          status: "ok",
+        },
+      },
+    });
+
+    const credential = { type: "public-key", id: "cred" };
+
+    await expect(
+      authenticateWithWebAuthnCredential("reauthenticate", credential),
+    ).resolves.toEqual({
+      data: {
+        status: "ok",
+      },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        url: "auth/flow/app/v1/auth/webauthn/reauthenticate",
+        data: { credential },
       }),
     );
   });

--- a/frontend/src/services/api/mfaApi.js
+++ b/frontend/src/services/api/mfaApi.js
@@ -246,7 +246,7 @@ export async function reauthenticateWithPassword(password) {
  * Re-authenticate with a TOTP/recovery code (for sensitive operations).
  */
 export async function reauthenticateWithMfaCode(code) {
-  const { data } = await allauthAppRequest("post", "/auth/reauthenticate", {
+  const { data } = await allauthAppRequest("post", "/auth/2fa/reauthenticate", {
     data: { code: String(code || "").trim() },
   });
   return data;

--- a/frontend/src/services/api/mfaApi.js
+++ b/frontend/src/services/api/mfaApi.js
@@ -73,7 +73,11 @@ export async function getWebAuthnRequestOptions(usage) {
  */
 export async function authenticateWithWebAuthnCredential(usage, credential) {
   const endpoint =
-    usage === "login" ? "/auth/webauthn/login" : "/auth/webauthn/authenticate";
+    usage === "login"
+      ? "/auth/webauthn/login"
+      : usage === "reauthenticate"
+        ? "/auth/webauthn/reauthenticate"
+        : "/auth/webauthn/authenticate";
   const { data } = await allauthAppRequest("post", endpoint, {
     data: { credential },
   });

--- a/frontend/src/services/api/mfaApi.js
+++ b/frontend/src/services/api/mfaApi.js
@@ -13,17 +13,30 @@ const EMPTY_TOTP = {
 
 /**
  * Fetch global MFA configuration (passkey login support, supported types).
- * Falls back to allauth headless config endpoint.
+ * Reads the headless config endpoint so the authenticated account pages
+ * do not need to hit an MFA challenge route just to learn feature flags.
  */
 export async function getMfaConfig() {
-  const { data } = await allauthAppRequest("get", "/auth/2fa/authenticate", {
-    includeSession: false,
-  });
-  const config = data?.data || {};
-  return {
-    passkey_login_enabled: config?.passkey_login_enabled ?? false,
-    supported_types: config?.types || [],
-  };
+  try {
+    const { data } = await allauthAppRequest("get", "/config");
+    const config = data?.data?.mfa || data?.data || {};
+    return {
+      passkey_login_enabled: config?.passkey_login_enabled ?? false,
+      supported_types: config?.supported_types || config?.types || [],
+    };
+  } catch (error) {
+    if (error?.response?.status !== 401) {
+      throw error;
+    }
+    const flows =
+      error?.response?.data?.data?.flows || error?.response?.data?.flows || [];
+    return {
+      passkey_login_enabled: flows.some(
+        (flow) => flow?.id === "mfa_login_webauthn",
+      ),
+      supported_types: [],
+    };
+  }
 }
 
 // ─── MFA Authentication (login / reauthentication) ──────────────────────────
@@ -44,7 +57,11 @@ export async function authenticateMfaCode(code) {
  */
 export async function getWebAuthnRequestOptions(usage) {
   const endpoint =
-    usage === "login" ? "/auth/webauthn/login" : "/auth/webauthn/authenticate";
+    usage === "login"
+      ? "/auth/webauthn/login"
+      : usage === "reauthenticate"
+        ? "/auth/webauthn/reauthenticate"
+        : "/auth/webauthn/authenticate";
   const { data } = await allauthAppRequest("get", endpoint);
   return data?.data?.request_options || data?.data || data;
 }
@@ -128,13 +145,19 @@ export async function listAuthenticators() {
 
 /**
  * Get WebAuthn registration (creation) options for adding a new credential.
- * @param {{ name?: string }} options
+ * @param {{ name?: string, passwordless?: boolean }} options
  */
-export async function getWebAuthnRegistrationOptions({ name } = {}) {
+export async function getWebAuthnRegistrationOptions({
+  name,
+  passwordless = false,
+} = {}) {
+  const params = {};
+  if (name) params.name = name;
+  if (passwordless) params.passwordless = "";
   const { data } = await allauthAppRequest(
     "get",
     "/account/authenticators/webauthn",
-    { params: name ? { name } : undefined },
+    { params: Object.keys(params).length ? params : undefined },
   );
   return data?.data?.creation_options || data?.data || data;
 }


### PR DESCRIPTION
This pull request introduces several improvements and updates across environment configuration, CI workflows, backend API error handling, and account management logic. The changes focus on better environment separation, enhanced security and observability support, improved error responses, and stricter API rate limiting for authentication endpoints.

**Environment and Configuration Improvements:**

* Expanded allowed and trusted hosts in `.env.example` and CI environment variables, adding dedicated `DJANGO_ADMIN_HOSTS` and `DJANGO_API_HOSTS` for clearer separation of admin and API endpoints, and updated CSRF trusted origins to include these new hosts. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL8-R11) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L151-R168) [[3]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L180-R207)
* Changed `PUBLIC_API_URL` to point to a dedicated API host (`https://api.joutak.ru`) and added OpenTelemetry (OTEL) configuration options for distributed tracing and metrics.
* Updated proxy and CORS settings, including enabling `ACCOUNT_TRUST_PROXY_HEADERS` by default for deployments behind a reverse proxy.

**CI/CD Workflow Enhancements:**

* Added a new `smoke_stack` job to the GitHub Actions workflow, which runs end-to-end smoke tests with and without OTEL endpoints enabled, ensuring stack health and observability integration.
* Improved frontend check jobs by introducing a matrix strategy and a verification step to ensure all frontend checks pass before proceeding. [[1]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8L52-R52) [[2]](diffhunk://#diff-3ab46ee209a127470fce3c2cf106b1a1dbadbb929a4b5b13656a4bc4ce19c0b8R92-R103)
* Updated Bandit security checks to include additional backend directories.

**Backend API Improvements:**

* Changed field-level validation errors to return HTTP status 422 instead of 400, aligning with schema validation conventions and improving error handling consistency for clients. [[1]](diffhunk://#diff-86725ba2ca5dcf20e3caeede3300e311a5cf0fa47b1187b1fcdd11d1b7e45891R34-R41) [[2]](diffhunk://#diff-81f69a7f3e9d4a9f9379a1def5a30d5709dedefb1494c0ec12f65831c45b09c3R5-L6) [[3]](diffhunk://#diff-81f69a7f3e9d4a9f9379a1def5a30d5709dedefb1494c0ec12f65831c45b09c3L25-R27)
* Updated API endpoint response schemas to include 400 and 409 error codes where appropriate, making error responses more explicit and comprehensive. [[1]](diffhunk://#diff-3527dbdd4268c2fd4bb579eee9c7b26a30826092a03ef0dd5b2bb82a6abcf261L147-R153) [[2]](diffhunk://#diff-3527dbdd4268c2fd4bb579eee9c7b26a30826092a03ef0dd5b2bb82a6abcf261L161-R176) [[3]](diffhunk://#diff-3527dbdd4268c2fd4bb579eee9c7b26a30826092a03ef0dd5b2bb82a6abcf261L175-R194) [[4]](diffhunk://#diff-5299f177cdb269d7e89d163706110e10cabcd328014f0bb97e5dac52f2f591b6R39)

**Security and Rate Limiting:**

* Added per-method rate limiting to sensitive authentication endpoints (JWT issuance, refresh, password change), returning HTTP 429 on excessive requests to mitigate abuse. [[1]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdR23-R28) [[2]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdL47-R63) [[3]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdR104) [[4]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdR113-R116) [[5]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdL114-R134) [[6]](diffhunk://#diff-9eea3e330f3cd4e9d733a802b8f2514c5c8c6b6f83ea81c5d0542f20d34ea6cdR143-R144)

**Account Status and Personalization Logic:**

* Refactored account status computation to provide more granular personalization context and prompt variants, distinguishing between new registrations, legacy users, and fully personalized accounts. [[1]](diffhunk://#diff-664bb0a1835ba3c347734a9d5053eb1d42188fd71a255b3812a14f3965223b6bL10-R21) [[2]](diffhunk://#diff-664bb0a1835ba3c347734a9d5053eb1d42188fd71a255b3812a14f3965223b6bR43-R58)

**Other:**

* Removed the `.flake8` configuration file, possibly in favor of a different linting setup.

These changes collectively improve deployment flexibility, security, developer experience, and user-facing error handling.