### PR TITLE
fix(homepage): BFF backend root fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md instructions for /Users/mihhailmatvejev/PycharmProjects/JouTakWeb
+
+## Git Commits
+
+Use Conventional Commits for git commits by default.
+
+Required format:
+`type(scope): description`
+
+Preferred types:
+`feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `ci`, `build`, `perf`, `style`, `revert`.
+
+Do not create non-canonical commit messages unless the user explicitly asks for a different format.
+
+## Pull Requests
+
+Do not prefix pull request titles with `[codex]`.
+Use a plain Conventional Commits-style PR title or another repository-approved title format that does not interfere with branch or PR naming logic.

--- a/frontend/src/services/__tests__/httpClient.test.js
+++ b/frontend/src/services/__tests__/httpClient.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBackendRoot } from "../http/client";
+
+describe("resolveBackendRoot", () => {
+  it("falls back to the local backend for unresolved runtime placeholders", () => {
+    expect(resolveBackendRoot("__JOUTAK_RUNTIME_API_URL__")).toBe(
+      "http://127.0.0.1:8000",
+    );
+  });
+
+  it("falls back to the local backend for localhost without a backend port", () => {
+    expect(resolveBackendRoot("http://localhost/")).toBe(
+      "http://127.0.0.1:8000",
+    );
+  });
+
+  it("preserves explicit backend origins", () => {
+    expect(resolveBackendRoot("https://api.example.test/api/")).toBe(
+      "https://api.example.test",
+    );
+    expect(resolveBackendRoot("https://api.example.test")).toBe(
+      "https://api.example.test",
+    );
+  });
+});

--- a/frontend/src/services/http/client.js
+++ b/frontend/src/services/http/client.js
@@ -26,7 +26,31 @@ function normalizeBackendRoot(value) {
   return trimmed.endsWith("/api") ? trimmed.slice(0, -4) : trimmed;
 }
 
-export const BACKEND_ROOT_URL = normalizeBackendRoot(BACKEND_URL);
+const LOCAL_BACKEND_FALLBACK_URL = "http://127.0.0.1:8000";
+
+function isRuntimePlaceholder(value) {
+  const raw = String(value || "").trim();
+  return raw.startsWith("__JOUTAK_RUNTIME_") && raw.endsWith("__");
+}
+
+export function resolveBackendRoot(value) {
+  const normalized = normalizeBackendRoot(value);
+  if (!normalized || isRuntimePlaceholder(normalized)) {
+    return LOCAL_BACKEND_FALLBACK_URL;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.hostname === "localhost" && !parsed.port) {
+      return LOCAL_BACKEND_FALLBACK_URL;
+    }
+    return normalized;
+  } catch {
+    return LOCAL_BACKEND_FALLBACK_URL;
+  }
+}
+
+export const BACKEND_ROOT_URL = resolveBackendRoot(BACKEND_URL);
 export const API_BASE = `${BACKEND_ROOT_URL}/api`;
 export const OTEL_EXPORTER_TRACES_URL =
   normalizeOptionalRuntimeValue(OTEL_TRACES_URL);


### PR DESCRIPTION
## What changed
- Added a safe backend-root resolver in the frontend HTTP client.
- If the runtime API URL placeholder is still unresolved, or local config points at `http://localhost/` without a backend port, BFF requests now fall back to `http://127.0.0.1:8000`.
- Added tests for the resolver behavior.

## Why
The homepage description disappeared because `/bff/pages/home` was being resolved against the frontend origin in local/preview setups. That returned `index.html` instead of JSON, so `hero.description` ended up empty.

## Impact
- Restores the JouTak intro text on the homepage in local preview/dev setups.
- Prevents the frontend from silently talking to itself for BFF requests when the backend origin is misconfigured.

## Validation
- `npm --prefix frontend test -- --run src/services/__tests__/httpClient.test.js src/services/__tests__/urlSafety.test.js`
- `npm --prefix frontend run build`
