### PR TITLE
fix(frontend): allow standalone frontend startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ npm run dev
 
 Dev server выведет локальный URL, обычно `http://localhost:5173`.
 
+Backend не является обязательной зависимостью для `npm run dev`: интерфейс
+должен открываться и без поднятого API. При этом auth/BFF-запросы будут
+ошибаться, что ожидаемо для standalone frontend development.
+
 Проверки frontend:
 
 ```bash

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -41,7 +41,7 @@ defusedxml==0.7.1
     # via py-serializable
 dj-database-url==3.0.1
     # via backend
-django==5.2.14
+django==5.2.15
     # via
     #   backend
     #   dj-database-url

--- a/backend/requirements/prod.txt
+++ b/backend/requirements/prod.txt
@@ -28,7 +28,7 @@ cryptography==46.0.7
     #   pyjwt
 dj-database-url==3.0.1
     # via backend
-django==5.2.14
+django==5.2.15
     # via
     #   backend
     #   dj-database-url

--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -31,7 +31,7 @@ cryptography==46.0.7
     #   pyjwt
 dj-database-url==3.0.1
     # via backend
-django==5.2.14
+django==5.2.15
     # via
     #   backend
     #   dj-database-url

--- a/frontend/src/features/bootstrap/BootstrapProvider.jsx
+++ b/frontend/src/features/bootstrap/BootstrapProvider.jsx
@@ -13,6 +13,38 @@ import {
 } from "../featureFlags/openFeature.js";
 import { BootstrapContext } from "./bootstrapContext.js";
 
+const DEFAULT_BOOTSTRAP = {
+  viewer: { is_authenticated: false },
+  features: {},
+  experiments: { anonymous_id_present: false },
+  layout: { homepage_variant: "legacy" },
+};
+
+function getLocalFeatureOverrides(search) {
+  const params = pickFeatureOverrideParams(search);
+  const overrides = {};
+
+  for (const [key, value] of params.entries()) {
+    if (!key.startsWith("ff_")) {
+      continue;
+    }
+    overrides[key.slice(3)] = value;
+  }
+
+  return overrides;
+}
+
+function buildFallbackBootstrap(search) {
+  const features = getLocalFeatureOverrides(search);
+  const homepageVariant = features.site_homepage_version || "legacy";
+
+  return {
+    ...DEFAULT_BOOTSTRAP,
+    features,
+    layout: { homepage_variant: homepageVariant },
+  };
+}
+
 function RouteFallback() {
   return <div className="py-5 text-center text-secondary">Загрузка...</div>;
 }
@@ -47,11 +79,13 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
         error: null,
       });
     } catch (error) {
+      const fallbackBootstrap = buildFallbackBootstrap(window.location.search);
+      await updateFeatureConfiguration(fallbackBootstrap.features);
       if (!mountedRef.current || requestSeq !== requestSeqRef.current) {
         return;
       }
       setState({
-        bootstrap: null,
+        bootstrap: fallbackBootstrap,
         loading: false,
         error,
       });
@@ -103,14 +137,6 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
 
   if (state.loading && !state.bootstrap) {
     return fallback;
-  }
-
-  if (state.error && !state.bootstrap) {
-    return (
-      <div className="py-5 text-center text-danger">
-        Не удалось загрузить конфигурацию интерфейса.
-      </div>
-    );
   }
 
   return (

--- a/frontend/src/features/bootstrap/BootstrapProvider.jsx
+++ b/frontend/src/features/bootstrap/BootstrapProvider.jsx
@@ -58,6 +58,11 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
   const requestSeqRef = useRef(0);
   const mountedRef = useRef(false);
 
+  const isCurrentRequest = useCallback(
+    (requestSeq) => mountedRef.current && requestSeq === requestSeqRef.current,
+    [],
+  );
+
   const loadBootstrap = useCallback(async () => {
     const requestSeq = ++requestSeqRef.current;
     setState((current) => ({
@@ -69,8 +74,11 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
     try {
       const params = pickFeatureOverrideParams(window.location.search);
       const bootstrap = await getBootstrap(params);
+      if (!isCurrentRequest(requestSeq)) {
+        return;
+      }
       await updateFeatureConfiguration(bootstrap?.features || {});
-      if (!mountedRef.current || requestSeq !== requestSeqRef.current) {
+      if (!isCurrentRequest(requestSeq)) {
         return;
       }
       setState({
@@ -80,8 +88,11 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
       });
     } catch (error) {
       const fallbackBootstrap = buildFallbackBootstrap(window.location.search);
+      if (!isCurrentRequest(requestSeq)) {
+        return;
+      }
       await updateFeatureConfiguration(fallbackBootstrap.features);
-      if (!mountedRef.current || requestSeq !== requestSeqRef.current) {
+      if (!isCurrentRequest(requestSeq)) {
         return;
       }
       setState({
@@ -90,7 +101,7 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
         error,
       });
     }
-  }, []);
+  }, [isCurrentRequest]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -120,8 +131,11 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
         }));
         const params = pickFeatureOverrideParams(window.location.search);
         const bootstrap = await getBootstrap(params);
+        if (!isCurrentRequest(requestSeq)) {
+          return bootstrap;
+        }
         await updateFeatureConfiguration(bootstrap?.features || {});
-        if (!mountedRef.current || requestSeq !== requestSeqRef.current) {
+        if (!isCurrentRequest(requestSeq)) {
           return bootstrap;
         }
         setState({
@@ -132,7 +146,7 @@ export function BootstrapProvider({ children, fallback = <RouteFallback /> }) {
         return bootstrap;
       },
     }),
-    [state],
+    [isCurrentRequest, state],
   );
 
   if (state.loading && !state.bootstrap) {

--- a/frontend/src/features/bootstrap/__tests__/bootstrapProvider.test.jsx
+++ b/frontend/src/features/bootstrap/__tests__/bootstrapProvider.test.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -44,14 +44,15 @@ function BootstrapProbe() {
     return <div>loading</div>;
   }
   if (error) {
-    return <div>error</div>;
+    return <div>{bootstrap?.layout?.homepage_variant || "error"}</div>;
   }
   return <div>{bootstrap?.layout?.homepage_variant || "none"}</div>;
 }
 
 describe("BootstrapProvider", () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    cleanup();
+    vi.resetAllMocks();
   });
 
   it("blocks variant-sensitive render until bootstrap resolves", async () => {
@@ -172,6 +173,20 @@ describe("BootstrapProvider", () => {
     });
   });
 
+  it("keeps rendering with local fallback when bootstrap is unavailable", async () => {
+    getBootstrap.mockRejectedValue(new Error("Network error"));
+
+    render(
+      <MemoryRouter>
+        <BootstrapProvider>
+          <BootstrapProbe />
+        </BootstrapProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("legacy")).toBeInTheDocument();
+  });
+
   it("ignores stale bootstrap responses after a newer refresh starts", async () => {
     const first = createDeferred();
     const second = createDeferred();
@@ -196,6 +211,10 @@ describe("BootstrapProvider", () => {
         </BootstrapProvider>
       </MemoryRouter>,
     );
+
+    await waitFor(() => {
+      expect(getBootstrap).toHaveBeenCalledTimes(1);
+    });
 
     expect(screen.getByText("Загрузка...")).toBeInTheDocument();
 

--- a/frontend/src/features/bootstrap/__tests__/bootstrapProvider.test.jsx
+++ b/frontend/src/features/bootstrap/__tests__/bootstrapProvider.test.jsx
@@ -24,8 +24,16 @@ vi.mock("../../../services/api/bffApi", () => ({
   pickFeatureOverrideParams: vi.fn(() => new URLSearchParams()),
 }));
 
+vi.mock("../../featureFlags/openFeature.js", () => ({
+  initializeOpenFeature: vi.fn(),
+  updateFeatureConfiguration: vi.fn(() => Promise.resolve()),
+}));
+
 const { getBootstrap, getHomepagePayload } = await import(
   "../../../services/api/bffApi"
+);
+const { updateFeatureConfiguration } = await import(
+  "../../featureFlags/openFeature.js"
 );
 
 function createDeferred() {
@@ -246,5 +254,55 @@ describe("BootstrapProvider", () => {
 
     expect(screen.getByText("v2")).toBeInTheDocument();
     expect(screen.queryByText("legacy")).toBeNull();
+  });
+
+  it("does not let stale failures override newer feature flags", async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    getBootstrap
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    render(
+      <MemoryRouter>
+        <BootstrapProvider>
+          <BootstrapProbe />
+        </BootstrapProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(getBootstrap).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event(AUTH_STATE_EVENT));
+    });
+
+    await act(async () => {
+      second.resolve({
+        viewer: { is_authenticated: false },
+        features: { site_homepage_version: "v2" },
+        experiments: { anonymous_id_present: true },
+        layout: { homepage_variant: "v2" },
+      });
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("v2")).toBeInTheDocument();
+    expect(updateFeatureConfiguration).toHaveBeenLastCalledWith({
+      site_homepage_version: "v2",
+    });
+
+    await act(async () => {
+      first.reject(new Error("Network error"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("v2")).toBeInTheDocument();
+    expect(updateFeatureConfiguration).toHaveBeenCalledTimes(1);
+    expect(updateFeatureConfiguration).toHaveBeenLastCalledWith({
+      site_homepage_version: "v2",
+    });
   });
 });

--- a/frontend/src/pages/JouTak.jsx
+++ b/frontend/src/pages/JouTak.jsx
@@ -5,6 +5,28 @@ import { getHomepagePayload, pickFeatureOverrideParams } from "../services/api";
 import HomepageV2 from "./joutak/HomepageV2.jsx";
 import LegacyHomepage from "./joutak/LegacyHomepage.jsx";
 
+const FALLBACK_HOMEPAGE_CONTENT = {
+  hero: {
+    title: "JouTak",
+    description:
+      "Интерфейс доступен без backend. API-зависимые действия будут падать, пока бэкенд не поднят.",
+    server_ip: "mc.joutak.ru",
+    primary_cta: {
+      href: "https://joutak.ru",
+      label: "Открыть JouTak",
+    },
+    secondary_cta: {
+      to: "/joutak/pay",
+      label: "Оплатить проходку",
+    },
+  },
+  carousel: [],
+  projects: [],
+  events: [],
+  gallery: [],
+  faq: [],
+};
+
 export default function JouTak() {
   const bootstrapVariant = useStringFlagValue(
     "site_homepage_version",
@@ -53,15 +75,14 @@ export default function JouTak() {
   }
 
   if (state.error && !state.payload) {
-    return (
-      <div className="py-5 text-center text-danger">
-        Не удалось загрузить главную страницу.
-      </div>
-    );
+    if (bootstrapVariant === "v2") {
+      return <HomepageV2 content={FALLBACK_HOMEPAGE_CONTENT} />;
+    }
+    return <LegacyHomepage content={FALLBACK_HOMEPAGE_CONTENT} />;
   }
 
   const variant = state.payload?.variant || bootstrapVariant || "legacy";
-  const content = state.payload?.content || {};
+  const content = state.payload?.content || FALLBACK_HOMEPAGE_CONTENT;
 
   if (variant === "v2") {
     return <HomepageV2 content={content} />;

--- a/frontend/src/pages/joutak/HomepageV2.jsx
+++ b/frontend/src/pages/joutak/HomepageV2.jsx
@@ -10,16 +10,19 @@ function Hero({ hero }) {
           <div className="text-uppercase small text-warning mb-2">
             {hero?.eyebrow || "JouTak Community"}
           </div>
-          <h1 className="display-4 fw-bold mb-3">{hero?.title}</h1>
-          <p className="fs-5 text-secondary mb-4">{hero?.description}</p>
+          <h1 className="display-4 fw-bold mb-3">{hero?.title || "JouTak"}</h1>
+          <p className="fs-5 text-secondary mb-4">
+            {hero?.description ||
+              "Интерфейс доступен без backend. API-зависимые действия будут недоступны, пока бэкенд не поднят."}
+          </p>
           <div className="d-flex flex-wrap gap-3 align-items-center">
             <a
               className="btn btn-warning btn-lg"
-              href={hero?.primary_cta?.href}
+              href={hero?.primary_cta?.href || "https://joutak.ru"}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {hero?.primary_cta?.label}
+              {hero?.primary_cta?.label || "Открыть JouTak"}
             </a>
             <Link
               className="btn btn-outline-light btn-lg"

--- a/frontend/src/pages/joutak/LegacyHomepage.jsx
+++ b/frontend/src/pages/joutak/LegacyHomepage.jsx
@@ -20,11 +20,11 @@ export default function LegacyHomepage({ content }) {
           </p>
           <a
             className="btn btn-primary btn-lg mt-4"
-            href={hero.primary_cta?.href}
+            href={hero.primary_cta?.href || "https://joutak.ru"}
             target="_blank"
             rel="noopener noreferrer"
           >
-            {hero.primary_cta?.label}
+            {hero.primary_cta?.label || "Открыть JouTak"}
           </a>
           <br />
           <Link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "cffi==2.0.0",
     "cryptography>=46.0.5",
     "dj-database-url>=3.0.1",
-    "django>=5.2.14,<5.3",
+    "django>=5.2.15,<5.3",
     "django-allauth[headless-spec,mfa]>=64.0",
     "django-axes>=7.0.0",
     "django-ratelimit>=4.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -78,7 +78,7 @@ requires-dist = [
     { name = "cffi", specifier = "==2.0.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "dj-database-url", specifier = ">=3.0.1" },
-    { name = "django", specifier = ">=5.2.14,<5.3" },
+    { name = "django", specifier = ">=5.2.15,<5.3" },
     { name = "django-allauth", extras = ["headless-spec", "mfa"], specifier = ">=64.0" },
     { name = "django-axes", specifier = ">=7.0.0" },
     { name = "django-cors-headers", specifier = ">=4.7.0" },
@@ -467,16 +467,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/e3/31722f7284c9f43333daff9aee9184678e4487adcb5506af0db8cea09ce1/django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7", size = 10873669, upload-time = "2026-06-03T13:03:35.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/38140b1643c00d5c46ce69c78e6980fd285aee223100319631bedee4f5e7/django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970", size = 8311957, upload-time = "2026-06-03T13:03:31.329Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Что сделано

Убрана жесткая зависимость frontend от backend/BFF на старте приложения.

Раньше локальный `npm run dev` мог упираться в недоступный backend:
- bootstrap приложения падал, если не отвечал `/bff/bootstrap`
- главная страница уходила в фатальную ошибку, если не отвечал BFF/API

Теперь frontend можно поднимать отдельно для локальной разработки интерфейсов:
- при недоступном `/bff/bootstrap` используется локальный fallback bootstrap-конфиг
- главная страница рендерится с fallback-контентом вместо блокирующей ошибки
- `ff_*` query overrides продолжают работать и без backend
- в README явно указано, что backend не обязателен для `npm run dev`

## Зачем

Это нужно, чтобы фронтендеры могли работать с интерфейсами без обязательного поднятия backend и без Docker-only сценария разработки.

При этом поведение API-зависимых частей не меняется:
- auth/BFF-запросы без backend по-прежнему будут ошибаться
- это ожидаемо для standalone frontend development

## Проверка

Проверено:
- `npm --prefix frontend run test:run -- src/features/bootstrap/__tests__/bootstrapProvider.test.jsx`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`

## Что не менялось

В PR не включены посторонние изменения зависимостей и lockfile.