### PR TITLE
chore(carousel): update carousel images's URLs on main page

### DIFF
--- a/backend/bff/services.py
+++ b/backend/bff/services.py
@@ -25,23 +25,23 @@ LEGACY_HOMEPAGE = {
     },
     "carousel": [
         {
-            "src": "https://cloud.joutak.ru/s/2oQALeqNkndEQMw/preview",
+            "src": "https://cloud.joutak.ru/s/ZZg89sgcx6X9cxp/preview",
             "alt": "Центральный район сервера",
         },
         {
-            "src": "https://cloud.joutak.ru/s/fAn6tq8jn3wcbzy/preview",
+            "src": "https://cloud.joutak.ru/s/mFfm4HqBzYm5Wxc/preview",
             "alt": "Большой гриб на нулевых координатах",
         },
         {
-            "src": "https://cloud.joutak.ru/s/oD9SmGSnqGCYqLP/preview",
+            "src": "https://cloud.joutak.ru/s/z3zBa6cBZ8jbnsS/preview",
             "alt": "Летучий Голландец в Казахстане",
         },
         {
-            "src": "https://cloud.joutak.ru/s/D8MH8Bmia4f6Ab5/preview",
+            "src": "https://cloud.joutak.ru/s/2kZ8WNN49aqn8yd/preview",
             "alt": "Крупная сходка новых игроков 2025",
         },
         {
-            "src": "https://cloud.joutak.ru/s/3ebFJexTFSntZmL/preview",
+            "src": "https://cloud.joutak.ru/s/RcA26gKCY495Y8j/preview",
             "alt": "Центральный хаб в Нижнем мире",
         },
     ],


### PR DESCRIPTION
Изменены ссылки для подгрузки изображений в карусели на главной странице. 

Проверено на локальной версии, работает стабильно.

<img width="908" height="454" alt="image" src="https://github.com/user-attachments/assets/96190168-dce1-41ca-a2c0-03c4f8dbed07" />
